### PR TITLE
added MF Tick Tracking

### DIFF
--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -3,6 +3,8 @@
     <div class="header">
       <div class="logo"></div>
       <h1 class="text-primary">TBCC Shadow Priest Analyzer</h1>
+      <div>Changing this here</div>
+      
     </div>
 
     <mat-card>

--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -3,7 +3,6 @@
     <div class="header">
       <div class="logo"></div>
       <h1 class="text-primary">TBCC Shadow Priest Analyzer</h1>
-      <div>Changing this here</div>
       
     </div>
 

--- a/src/app/report/casts.component.html
+++ b/src/app/report/casts.component.html
@@ -60,6 +60,17 @@
           {{ format(stats.channelStats.avgNextCastLatency, 2, 's') }}
         </span>
       </div>
+      <div *ngIf="stats.hasChannelStats">
+        Clipped MF Casts:
+        <span [ngClass]="highlight.clippedTicks(stats)">{{ stats.channelStats.clipCount }}</span>
+      </div>
+      <div *ngIf="stats.hasChannelStats">
+        Clipped Ticks:
+        <span [ngClass]="highlight.clippedTicks(stats)">
+          {{ format(stats.channelStats.clippedTicks) }}
+          ({{ format(stats.channelStats.missedTickPercent * 100, 2) }}%)
+        </span>
+      </div>
     </div>
 
     <div class="aggregates spellpower">

--- a/src/app/report/models/spell-stats.ts
+++ b/src/app/report/models/spell-stats.ts
@@ -26,7 +26,11 @@ export class SpellStats {
   private _channelStats: IChannelStats = {
     castCount: 0,
     totalNextCastLatency: 0,
-    avgNextCastLatency: 0
+    avgNextCastLatency: 0,
+    clipCount: 0,
+    clippedTicks: 0,
+    missedTickPercent: 0,
+    expectedTicks: 0
   };
 
   private _cooldownStats: ICooldownStats = {
@@ -208,6 +212,14 @@ export class SpellStats {
     if (this.addChannelStats(cast)) {
       this._channelStats.castCount++;
       this._channelStats.totalNextCastLatency += cast.nextCastLatency as number;
+      this._channelStats.expectedTicks += spellData.maxDamageInstances;
+      
+
+      if (cast.hits < spellData.maxDamageInstances) {
+        this._channelStats.clipCount++;
+        this._channelStats.clippedTicks += (spellData.maxDamageInstances - cast.hits);
+        console.log('this._channelStats.clipCount: ', this._channelStats.clipCount)
+      }
     }
 
     if (this.addCooldownStats(cast)) {
@@ -264,6 +276,10 @@ export class SpellStats {
       if (next.hasChannelStats) {
         this._channelStats.castCount += next.channelStats.castCount;
         this._channelStats.totalNextCastLatency += next.channelStats.totalNextCastLatency;
+        this._channelStats.clippedTicks += next.channelStats.clippedTicks;
+        this._channelStats.clipCount += next.channelStats.clipCount;
+        this._channelStats.expectedTicks += next.channelStats.expectedTicks;
+        this._channelStats.totalNextCastLatency += next.channelStats.totalNextCastLatency;
       }
 
       if (next.hasCooldownStats) {
@@ -309,6 +325,11 @@ export class SpellStats {
 
     if (this.hasChannelStats) {
       this._channelStats.avgNextCastLatency = this._channelStats.totalNextCastLatency / this._channelStats.castCount;
+
+      // what percentage of the total ticks I should have gotten were missed
+      if (this._channelStats.expectedTicks > 0) {
+        this._channelStats.missedTickPercent = this._channelStats.clippedTicks / this._channelStats.expectedTicks;
+      }
     }
 
     if (this.hasCooldownStats) {
@@ -409,6 +430,10 @@ export interface IChannelStats {
   castCount: number;
   totalNextCastLatency: number;
   avgNextCastLatency: number;
+  clipCount: number;
+  clippedTicks: number;
+  expectedTicks: number;
+  missedTickPercent: number;
 }
 
 export interface ICooldownStats {

--- a/src/app/report/models/spell-stats.ts
+++ b/src/app/report/models/spell-stats.ts
@@ -218,7 +218,6 @@ export class SpellStats {
       if (cast.hits < spellData.maxDamageInstances) {
         this._channelStats.clipCount++;
         this._channelStats.clippedTicks += (spellData.maxDamageInstances - cast.hits);
-        console.log('this._channelStats.clipCount: ', this._channelStats.clipCount)
       }
     }
 


### PR DESCRIPTION
This is the base tracking of MF Ticks. For now i think it might be worth while to only 'call' out MF's with 1 tick (meaning clipped before second tick). This would be the 'greatest' dps loss of MF - over not casting.